### PR TITLE
Fix for standalone cache file editing

### DIFF
--- a/haloreach/source/cache/cache_file_tag_resources_runtime.cpp
+++ b/haloreach/source/cache/cache_file_tag_resources_runtime.cpp
@@ -239,7 +239,12 @@ void *c_cache_file_reach::get_resource_page_data(
 		if (!last_separator)
 			last_separator = csstrrchr((char *)m_filename, '/');
 
-		csmemcpy(resource_cache_file_path, m_filename, last_separator - m_filename);
+		if (!last_separator) {
+			csmemcpy(resource_cache_file_path, m_filename, csstrlen(m_filename));
+		}
+		else {
+			csmemcpy(resource_cache_file_path, m_filename, last_separator - m_filename);
+		}
 
 		auto file_path = csstrrchr(shared_file->path.get_buffer(), '\\');
 


### PR DESCRIPTION
Edge case where a standalone file would be missing either '/' or '\\' and cause csmemcpy to throw an access violation error.